### PR TITLE
Switch build to junit platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,14 @@
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
-            <artifactId>cucumber-junit</artifactId>
+            <artifactId>cucumber-junit-platform-engine</artifactId>
             <version>7.16.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+            <version>1.10.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/StepDefinitions.java
+++ b/src/test/java/StepDefinitions.java
@@ -2,7 +2,7 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StepDefinitions {
     private WebDriver driver;


### PR DESCRIPTION
## Summary
- swap cucumber junit for JUnit Platform Engine
- use JUnit 5 assertions in step definitions
- add junit platform suite dependency
- keep example cucumber tests

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.6)*

------
https://chatgpt.com/codex/tasks/task_e_686b673b69bc83288910be41bccb0810