### PR TITLE
Add .gitignore for Maven projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Maven build directory
+/target/
+
+# Maven specific files
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# Maven wrapper binary
+.mvn/wrapper/maven-wrapper.jar
+
+# IDE directories and files
+.idea/
+*.iml
+*.ipr
+*.iws
+.project
+.classpath
+.settings/
+
+# Logs
+*.log


### PR DESCRIPTION
## Summary
- add `.gitignore` with entries for Maven builds, IDE files, and logs

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b68ec6ee88328ba3ff25614e84bc4