### PR TITLE
Remove Maven wrapper jar; download at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.mvn/wrapper/maven-wrapper.jar


### PR DESCRIPTION
## Summary
- add `.mvn/wrapper/maven-wrapper.jar` to `.gitignore`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b6a5fc0488328ab5373b4d4a94028